### PR TITLE
leveraging aliases from musicbrainz.

### DIFF
--- a/default.py
+++ b/default.py
@@ -689,7 +689,7 @@ class Main:
             if theartist.startswith(badSubstring):
                 searchartist = theartist.replace(badSubstring, "")
         mboptions = {"fmt":"json"} 
-        mbsearch = 'artist:"%s"' % searchartist
+        mbsearch = 'alias:"%s"' % searchartist
         query_times = {'last':0, 'current':time.time()}
         lw.log( ['parsing musicbrainz response for muiscbrainz ID'] )
         cached_mb_info = False


### PR DESCRIPTION
bands such as prince & the revolution are often tagged that way while their musicbrainz artist name is just the revolution, aliases are intended to resolve such disconnects.  this helped me out in a number of cases, although I could see a more complicated solution where a test of artist precedes an attempt at aliases.