### PR TITLE
feat(radio): add Audio Stream Monitor integration for radio streams

### DIFF
--- a/resources/lib/artistslideshow.py
+++ b/resources/lib/artistslideshow.py
@@ -317,7 +317,7 @@ class Main(xbmc.Player):
         if self._get_infolabel('ArtistSlideshow.Image'):
             self.SLIDESHOW.ClearImages(fadetoblack=fadetoblack)
         self._slideshow_thread_stop()
-        if self._is_playing() and (fadetoblack or clearartists) and not slideshowstopping:
+        if self._is_playing() and not slideshowstopping:
             self._slideshow_thread_start()
         if self._get_infolabel('ArtistSlideshow.ArtistBiography'):
             self._set_property('ArtistSlideshow.ArtistBiography')
@@ -549,6 +549,61 @@ class Main(xbmc.Player):
                 artist_names.extend(self._split_artists(playingartist))
         return artist_names, mbids
 
+    def _get_radiomonitor_artists_info(self):
+        """
+        Prefer metadata from service.audio.stream.monitor (Audio Stream Monitor)
+        when it indicates that a radio stream is playing.
+
+        This method is intentionally self-contained and only sets ARTISTS_INFO /
+        ALLARTISTS when RadioMonitor.Playing is true and an artist name is
+        available. In all other cases it returns False and allows the existing
+        Artist Slideshow logic to run unchanged.
+        """
+        try:
+            playing = xbmc.getInfoLabel(
+                'Window(Home).Property(RadioMonitor.Playing)')
+        except Exception as e:
+            LW.log(
+                ['unexpected error reading RadioMonitor.Playing, falling back to default logic', e])
+            return False
+        if not playing or playing.lower() != 'true':
+            # Audio Stream Monitor does not report an active radio stream,
+            # so fall back to the original Artist Slideshow logic.
+            return False
+
+        artist = xbmc.getInfoLabel(
+            'Window(Home).Property(RadioMonitor.Artist)').strip()
+        if not artist:
+            # Audio Stream Monitor is active (Playing=true) but does not yet
+            # provide a usable artist. In this case Artist Slideshow should
+            # not apply its own stream heuristic but simply wait until
+            # Audio Stream Monitor has full metadata.
+            # Intentionally set ARTISTS_INFO to empty and return True so that
+            # the original logic is skipped while ASM is in control.
+            self.ARTISTS_INFO = []
+            LW.log(
+                ['Audio Stream Monitor active but no artist yet, waiting for metadata'])
+            return True
+
+        mbid = xbmc.getInfoLabel(
+            'Window(Home).Property(RadioMonitor.MBID)').strip()
+
+        artist_names = [artist]
+        mbids = [mbid] if mbid else []
+
+        artists_info = self._get_current_artists_filtered(artist_names, mbids)
+        if not artists_info:
+            return False
+
+        # Only update ARTISTS_INFO here. ALLARTISTS is intentionally left
+        # unchanged so that _playback_stopped_or_changed can still detect
+        # a change in the artist list and trigger a new slideshow when
+        # Audio Stream Monitor updates the metadata.
+        self.ARTISTS_INFO = artists_info
+        LW.log(['using artist information from Audio Stream Monitor',
+               self.ARTISTS_INFO])
+        return True
+
     def _get_current_artists_filtered(self, artist_names, mbids):
         artists_info = []
         LW.log(['starting with the following artists', artist_names])
@@ -567,6 +622,8 @@ class Main(xbmc.Player):
         return artists_info
 
     def _get_current_artists_info(self):
+        if self._get_radiomonitor_artists_info():
+            return
         featured_artists = ''
         artist_names = []
         mbids = []

--- a/resources/lib/artistslideshow.py
+++ b/resources/lib/artistslideshow.py
@@ -317,7 +317,7 @@ class Main(xbmc.Player):
         if self._get_infolabel('ArtistSlideshow.Image'):
             self.SLIDESHOW.ClearImages(fadetoblack=fadetoblack)
         self._slideshow_thread_stop()
-        if self._is_playing() and not slideshowstopping:
+        if self._is_playing() and (fadetoblack or clearartists) and not slideshowstopping:
             self._slideshow_thread_start()
         if self._get_infolabel('ArtistSlideshow.ArtistBiography'):
             self._set_property('ArtistSlideshow.ArtistBiography')


### PR DESCRIPTION
﻿Summary:

- Adds `_get_radiomonitor_artists_info()` which reads `RadioMonitor.Playing`, `RadioMonitor.Artist`, and `RadioMonitor.MBID` from service.audio.stream.monitor and uses that metadata when a radio stream is active.
- Integrates this check into `_get_current_artists_info()` as a first step — if RadioMonitor returns a usable artist, the existing logic is skipped.
- Only modifies `resources/lib/artistslideshow.py`.

Note on previous changes:
Sorry again for the earlier mess — I believed I had reverted unintended edits but I had not. I will no longer change core logic, language files, or unrelated files in this PR.

About the fade-to-black change:
I originally introduced a small fix because I observed that when both `fadetoblack` and `clearartists` were False the slideshow thread could be stopped and not restarted, leaving the UI without images. I have removed that fix from this PR so you can decide whether to apply it or handle it differently in your tree.

Thanks for your patience.
